### PR TITLE
updating copyright and fixing JS error on homepage

### DIFF
--- a/resources/views/pages/layout.blade.php
+++ b/resources/views/pages/layout.blade.php
@@ -23,7 +23,7 @@
             </div>
         </div><!-- /.jumbotron -->
 
-        <div id="categories" class="container">
+        <div id="home-categories" class="container">
             <div class="row">
                 <div class="col-md-4">
                     <div class="medal"><img src="/images/overall_icon.png" alt="Overall Results" width="90"></div>
@@ -60,7 +60,7 @@
 
         <footer>
             <div class="container">
-                <p>&copy; 2017 James Gifford</p>
+                <p>&copy; 2019 James Gifford</p>
             <div class="container">
         </footer>
 


### PR DESCRIPTION
I forked this repo to see if I could help update the site with the 2018 and 2019 data. I haven't figured out that part, but I updated the copyright and fixed an ID name conflict that caused a JS error on homepage scroll.  